### PR TITLE
Fixed has_gravity proc being confusingly used/named

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -128,7 +128,7 @@
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
 ///from base of atom/handle_atom_del(): (atom/deleted)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"
-///from base of atom/has_gravity(): (turf/location, list/forced_gravities)
+///from base of atom/get_gravity(): (turf/location, list/forced_gravities)
 #define COMSIG_ATOM_HAS_GRAVITY "atom_has_gravity"
 ///from proc/get_rad_contents(): ()
 #define COMSIG_ATOM_RAD_PROBE "atom_rad_probe"
@@ -219,7 +219,7 @@
 
 ///from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_CHANGE "turf_change"
-///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
+///from base of atom/get_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"
 ///from base of turf/multiz_turf_del(): (turf/source, direction)
 #define COMSIG_TURF_MULTIZ_DEL "turf_multiz_del"

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -122,7 +122,7 @@ SUBSYSTEM_DEF(throwing)
 	//calculate how many tiles to move, making up for any missed ticks.
 	var/tilestomove = CEILING(min(((((world.time+world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed*MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
 	while (tilestomove-- > 0)
-		if ((dist_travelled >= maxrange || AM.loc == target_turf) && (A && A.has_gravity()))
+		if ((dist_travelled >= maxrange || AM.loc == target_turf) && (A && A.get_gravity()))
 			finalize()
 			return
 

--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -119,7 +119,7 @@
 		ridden.unbuckle_mob(M)
 
 /datum/riding/proc/Process_Spacemove(direction)
-	if(ridden.has_gravity())
+	if(ridden.get_gravity())
 		return TRUE
 
 	return FALSE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -387,7 +387,7 @@ var/list/mob/living/forced_ambiance_list = new
 	if(!L.lastarea)
 		L.lastarea = src
 	var/area/oldarea = L.lastarea
-	if((oldarea.has_gravity == 0) && (has_gravity == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
+	if((oldarea.get_gravity() == 0) && (get_gravity() == 1) && (L.m_intent == "run")) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
 		L.update_floating( L.Check_Dense_Object() )
 
@@ -432,10 +432,10 @@ var/list/mob/living/forced_ambiance_list = new
 	src.has_gravity = gravitystate
 
 	for(var/mob/M in src)
-		if(has_gravity)
+		if(get_gravity())
 			thunk(M)
 		M.update_floating( M.Check_Dense_Object() )
-		M.update_gravity(has_gravity)
+		M.update_gravity(get_gravity())
 
 /area/proc/thunk(mob)
 	if(istype(get_turf(mob), /turf/space)) // Can't fall onto nothing.
@@ -476,17 +476,17 @@ var/list/mob/living/forced_ambiance_list = new
 			for(var/obj/machinery/door/blast/temp_blast in src)
 				temp_blast.open()
 
-/area/has_gravity()
+/area/get_gravity()
 	return has_gravity
 
-/area/space/has_gravity()
+/area/space/get_gravity()
 	return 0
 
-/proc/has_gravity(atom/AT, turf/T)
+/proc/get_gravity(atom/AT, turf/T)
 	if(!T)
 		T = get_turf(AT)
 	var/area/A = get_area(T)
-	if(A && A.has_gravity())
+	if(A && A.get_gravity())
 		return 1
 	return 0
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -571,13 +571,13 @@
 /atom/proc/InsertedContents()
 	return contents
 
-/atom/proc/has_gravity(turf/T)
+/atom/proc/get_gravity(turf/T)
 	if(!T || !isturf(T))
 		T = get_turf(src)
 	if(istype(T, /turf/space)) // Turf never has gravity
 		return FALSE
 	var/area/A = get_area(T)
-	if(A && A.has_gravity())
+	if(A && A.get_gravity())
 		return TRUE
 	return FALSE
 

--- a/code/game/mecha/combat/fighter.dm
+++ b/code/game/mecha/combat/fighter.dm
@@ -167,7 +167,7 @@
 	return (stabilization_enabled && has_charge(step_energy_drain))
 
 /obj/mecha/combat/fighter/proc/consider_gravity(var/moved = FALSE)
-	var/gravity = has_gravity()
+	var/gravity = get_gravity()
 	if(gravity && ground_capable && occupant)
 		start_hover()
 	else if((!gravity && ground_capable) || !occupant)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -136,7 +136,7 @@
 				W.set_color()
 				W.set_up(my_target)
 
-		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
+		if((istype(usr.loc, /turf/space)) || (usr.lastarea.get_gravity() == 0))
 			user.inertia_dir = get_dir(target, user)
 			step(user, user.inertia_dir)
 	else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -160,7 +160,7 @@
 /turf/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	var/turf/T = get_turf(user)
 	var/area/A = T.loc
-	if((istype(A) && !(A.has_gravity)) || (istype(T,/turf/space)))
+	if((istype(A) && !(A.get_gravity())) || (istype(T,/turf/space)))
 		return
 	if(istype(O, /obj/screen))
 		return
@@ -315,7 +315,7 @@
 // Called when turf is hit by a thrown object
 /turf/hitby(atom/movable/AM as mob|obj, var/speed)
 	if(density)
-		if(!has_gravity(AM)) //Checked a different codebase for reference. Turns out it's only supposed to happen in no-gravity
+		if(!get_gravity(AM)) //Checked a different codebase for reference. Turns out it's only supposed to happen in no-gravity
 			spawn(2)
 				step(AM, turn(AM.last_move, 180)) //This makes it float away after hitting a wall in 0G
 		if(isliving(AM))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -941,7 +941,7 @@
 	if(wearer.transforming || !wearer.canmove)
 		return
 
-	if((istype(wearer.loc, /turf/space)) || (wearer.lastarea.has_gravity == 0))
+	if((istype(wearer.loc, /turf/space)) || (wearer.lastarea.get_gravity() == 0))
 		if(!wearer.Process_Spacemove(0))
 			return 0
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -112,7 +112,7 @@
 	data["safetyDisabled"] = safety_disabled
 	data["emagged"] = emagged
 	data["gravity"] = FALSE
-	if(linkedholodeck.has_gravity)
+	if(linkedholodeck.get_gravity())
 		data["gravity"] = TRUE
 
 	return data
@@ -264,7 +264,7 @@
 	else
 		loadProgram(powerdown_program, 0)
 
-		if(!linkedholodeck.has_gravity)
+		if(!linkedholodeck.get_gravity())
 			linkedholodeck.gravitychange(1)
 
 		active = 0
@@ -371,7 +371,7 @@
 	active = 1
 	update_use_power(USE_POWER_IDLE)
 
-	if(A.has_gravity)
+	if(A.get_gravity())
 		A.gravitychange(0)
 	else
 		A.gravitychange(1)
@@ -380,7 +380,7 @@
 	//Turn it back to the regular non-holographic room
 	loadProgram(powerdown_program, 0)
 
-	if(!linkedholodeck.has_gravity)
+	if(!linkedholodeck.get_gravity())
 		linkedholodeck.gravitychange(1)
 
 	active = 0

--- a/code/modules/looking_glass/lg_console.dm
+++ b/code/modules/looking_glass/lg_console.dm
@@ -66,7 +66,7 @@
 
 /obj/machinery/computer/looking_glass/tgui_data(mob/user, datum/tgui/ui, datum/tgui_state/state)
 	var/list/data = ..()
-	
+
 	var/list/program_list = list()
 	for(var/P in supported_programs)
 		program_list.Add(P)
@@ -78,7 +78,7 @@
 	data["supportedPrograms"] = program_list
 	data["currentProgram"] = current_program
 	data["immersion"] = immersion
-	if(my_area?.has_gravity)
+	if(my_area?.get_gravity())
 		data["gravity"] = 1
 	else
 		data["gravity"] = 0
@@ -88,7 +88,7 @@
 /obj/machinery/computer/looking_glass/tgui_act(action, list/params, datum/tgui/ui, datum/tgui_state/state)
 	if(..())
 		return TRUE
-	
+
 	switch(action)
 		if("program")
 			if(ready)
@@ -147,7 +147,7 @@
 
 	last_gravity_change = world.time
 
-	if(A.has_gravity)
+	if(A.get_gravity())
 		A.gravitychange(0)
 	else
 		A.gravitychange(1)

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -94,7 +94,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 	var/turf/turf = get_turf(src)
 	if(!istype(turf,/turf/space))
 		var/area/A = turf.loc
-		if(istype(A) && A.has_gravity)
+		if(istype(A) && A.get_gravity())
 			make_floating(0)
 			return
 		else if (Check_Shoegrip())

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1786,7 +1786,7 @@
 // Drag damage is handled in a parent
 /mob/living/carbon/human/dragged(var/mob/living/dragger, var/oldloc)
 	var/area/A = get_area(src)
-	if(lying && !buckled && A.has_gravity() && prob(getBruteLoss() * 200 / maxHealth))
+	if(lying && !buckled && A.get_gravity() && prob(getBruteLoss() * 200 / maxHealth))
 		var/bloodtrail = 1
 		if(species?.flags & NO_BLOOD)
 			bloodtrail = 0

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -279,7 +279,7 @@
 	if(m_intent == "run" && step_count++ % 2 != 0)
 		check_vorefootstep(m_intent, T) //CHOMPstation edit: sloshing reagent belly walk system
 	*/
-	if(shoes && loc == T && has_gravity(loc) && !flying)
+	if(shoes && loc == T && get_gravity(loc) && !flying)
 		if(SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION, m_intent))	//CHOMPEdit - Shoe step comsig
 			return
 	/*
@@ -302,7 +302,7 @@
 	if(buckled || lying || throwing)
 		return // people flying, lying down or sitting do not step
 
-	if(!has_gravity(src) && prob(75))
+	if(!get_gravity(src) && prob(75))
 		return // Far less likely to make noise in no gravity
 
 	playsound(T, S, volume, FALSE)

--- a/code/modules/mob/living/carbon/human/human_movement_ch.dm
+++ b/code/modules/mob/living/carbon/human/human_movement_ch.dm
@@ -25,7 +25,7 @@
 		return // no feet = no slosh? Might prevent some entities from sloshing around
 	if(buckled || lying || throwing)
 		return // people flying, lying down or sitting do not slosh
-	if(!has_gravity(src) && prob(75))
+	if(!get_gravity(src) && prob(75))
 		return // Far less likely to make noise in no gravity
 	playsound(T, S, volume, FALSE, preference = /datum/client_preference/digestion_noises)
 	return

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -64,7 +64,7 @@
 	//stuff in the stomach
 	//handle_stomach() //VOREStation Code
 
-	update_gravity(mob_has_gravity())
+	update_gravity(mob_get_gravity())
 
 	update_pulling()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1214,7 +1214,7 @@
 
 			src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
 
-			if((isspace(src.loc)) || (src.lastarea?.has_gravity == 0))
+			if((isspace(src.loc)) || (src.lastarea?.get_gravity() == 0))
 				src.inertia_dir = get_dir(target, src)
 				step(src, inertia_dir)
 			item.throw_at(target, throw_range, item.throw_speed, src)
@@ -1247,7 +1247,7 @@
 	//actually throw it!
 	src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
 
-	if((isspace(src.loc)) || (src.lastarea?.has_gravity == 0))
+	if((isspace(src.loc)) || (src.lastarea?.get_gravity() == 0))
 		src.inertia_dir = get_dir(target, src)
 		step(src, inertia_dir)
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -280,7 +280,7 @@ default behaviour is:
 
 /mob/living/proc/dragged(var/mob/living/dragger, var/oldloc)
 	var/area/A = get_area(src)
-	if(lying && !buckled && pull_damage() && A.has_gravity() && (prob(getBruteLoss() * 200 / maxHealth)))
+	if(lying && !buckled && pull_damage() && A.get_gravity() && (prob(getBruteLoss() * 200 / maxHealth)))
 		adjustBruteLoss(2)
 		visible_message("<span class='danger'>\The [src]'s [isSynthetic() ? "state" : "wounds"] worsen terribly from being dragged!</span>")
 
@@ -319,7 +319,7 @@ default behaviour is:
 
 	if(!isturf(loc))
 		return
-	else if(lastarea?.has_gravity == 0)
+	else if(lastarea?.get_gravity() == 0)
 		inertial_drift()
 	//VOREStation Edit Start
 	else if(flying)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -216,7 +216,7 @@
 			return result
 
 	// Can't control ourselves when drifting
-	if((isspace(loc) || my_mob.lastarea?.has_gravity == 0) && isturf(loc))
+	if((isspace(loc) || my_mob.lastarea?.get_gravity() == 0) && isturf(loc))
 		if(!my_mob.Process_Spacemove(0))
 			return 0
 
@@ -498,7 +498,7 @@
 
 		if(istype(turf,/turf/simulated/floor)) // Floors don't count if they don't have gravity
 			var/area/A = turf.loc
-			if(istype(A) && A.has_gravity == 0)
+			if(istype(A) && A.get_gravity() == 0)
 				if(shoegrip == null)
 					shoegrip = Check_Shoegrip() //Shoegrip is only ever checked when a zero-gravity floor is encountered to reduce load
 				if(!shoegrip)
@@ -539,8 +539,8 @@
 	return(prob_slip)
 */// CHOMPedit end.
 
-/mob/proc/mob_has_gravity(turf/T)
-	return has_gravity(src, T)
+/mob/proc/mob_get_gravity(turf/T)
+	return get_gravity(src, T)
 
 /mob/proc/update_gravity()
 	return

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -68,7 +68,7 @@
 
 
 	var/area/area = get_area(src)
-	if(area.has_gravity() && !can_overcome_gravity())
+	if(area.get_gravity() && !can_overcome_gravity())
 		if(direction == UP)
 			var/obj/structure/lattice/lattice = locate() in destination.contents
 			var/obj/structure/catwalk/catwalk = locate() in destination.contents
@@ -278,7 +278,7 @@
 
 	// No gravity in space, apparently.
 	var/area/area = get_area(src)
-	if(!area.has_gravity())
+	if(!area.get_gravity())
 		return
 
 	if(throwing)

--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -393,7 +393,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	for(var/mob/M as anything in player_list)
 		if(!(M.z in levels))
 			continue
-		M.update_gravity(M.mob_has_gravity())
+		M.update_gravity(M.mob_get_gravity())
 		shake_camera(M, 15, 1)
 		M.playsound_local(src, null, 50, 1, 0.5, S = alert_sound)
 

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -295,9 +295,9 @@
 		var/new_grav = 1
 		if(destination.flags & SLANDMARK_FLAG_ZERO_G)
 			var/area/new_area = get_area(destination)
-			new_grav = new_area.has_gravity
+			new_grav = new_area.get_gravity()
 		for(var/area/our_area in shuttle_area)
-			if(our_area.has_gravity != new_grav)
+			if(our_area.get_gravity() != new_grav)
 				our_area.gravitychange(new_grav)
 
 	// TODO - Old code used to throw stuff out of the way instead of squashing.  Should we?

--- a/maps/outpost21/outpost_areas.dm
+++ b/maps/outpost21/outpost_areas.dm
@@ -2025,7 +2025,7 @@
 	base_turf = /turf/space
 	ambience = AMBIENCE_SPACE
 
-/area/offworld/asteroidyard/external/has_gravity()
+/area/offworld/asteroidyard/external/get_gravity()
 	return 0
 
 /area/offworld/asteroidyard/external/yardzone
@@ -2271,7 +2271,7 @@
 	requires_power = FALSE
 	has_gravity = FALSE
 
-/area/virtual_reality/spacesim/has_gravity()
+/area/virtual_reality/spacesim/get_gravity()
 	return 0
 
 /area/specialty/hell

--- a/modular_chomp/code/datums/components/squeak.dm
+++ b/modular_chomp/code/datums/components/squeak.dm
@@ -120,9 +120,9 @@
 		if(I.item_flags & ABSTRACT)
 			return
 	//Annoyingly, our flight code doesn't set the movement_type, nor do we have a define for it. So I'm not adding it yet.
-	//if(arrived.movement_type & (FLYING|FLOATING) || !arrived.has_gravity())
+	//if(arrived.movement_type & (FLYING|FLOATING) || !arrived.get_gravity())
 	*/
-	if(!arrived.has_gravity())
+	if(!arrived.get_gravity())
 		return
 	if(ismob(arrived) && !arrived.density) // Prevents 10 overlapping mice from making an unholy sound while moving
 		return

--- a/modular_chomp/code/datums/elements/footstep.dm
+++ b/modular_chomp/code/datums/elements/footstep.dm
@@ -93,7 +93,7 @@
 	if(steps % 2)
 		return
 
-	if(steps != 0 && !has_gravity(source)) // don't need to step as often when you hop around
+	if(steps != 0 && !get_gravity(source)) // don't need to step as often when you hop around
 		return
 
 	. = list(

--- a/modular_chomp/code/datums/elements/slosh.dm
+++ b/modular_chomp/code/datums/elements/slosh.dm
@@ -86,7 +86,7 @@
 
 	if(source.buckled || source.lying || source.throwing || source.is_incorporeal())
 		return
-	if(!has_gravity(source) && prob(75))
+	if(!get_gravity(source) && prob(75))
 		return
 
 	playsound(source.loc, S, volume, FALSE, preference = /datum/preference/toggle/digestion_noises)

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -24,7 +24,7 @@
 
 	if(buckled || lying || throwing)
 		return // people flying, lying down or sitting do not slosh
-	if(!has_gravity(src) && prob(75))
+	if(!get_gravity(src) && prob(75))
 		return // Far less likely to make noise in no gravity
 	playsound(T, S, volume, FALSE, preference = /datum/client_preference/digestion_noises)
 	return

--- a/modular_outpost/maps/submaps/orbitalyard/orbitalyard.dm
+++ b/modular_outpost/maps/submaps/orbitalyard/orbitalyard.dm
@@ -177,7 +177,7 @@
 	ambience = AMBIENCE_OUTPOST21_SPACE
 	base_turf = /turf/space
 
-/area/submap/outpost21/asteroid_generic/has_gravity()
+/area/submap/outpost21/asteroid_generic/get_gravity()
 	return 0
 
 /area/submap/outpost21/structure_generic
@@ -187,7 +187,7 @@
 	ambience = AMBIENCE_OUTPOST21_SPACE
 	base_turf = /turf/space
 
-/area/submap/outpost21/structure_generic/has_gravity()
+/area/submap/outpost21/structure_generic/get_gravity()
 	return 0
 
 /area/submap/outpost21/structure_generic/lostshipa


### PR DESCRIPTION
area has var/has_gravity and /proc/has_gravity(), these are confusingly named the same. Due to this much of the code has used the variable directly. However multiple area overrides for space areas force this to 0 in the proc. The variable is used for gravity failures, and affects space areas inconsistently due to some code using the proc and some the var directly.

This PR corrects the behaviors by making all checks use the proc, now named get_gravity(), and the var has_gravity is only used internally or when copying areas.