### PR TITLE
Reagent transfers requires PPE

### DIFF
--- a/code/__defines/_reagents.dm
+++ b/code/__defines/_reagents.dm
@@ -1368,3 +1368,18 @@
 #define REAGENT_ID_BIOMASS_BELLY "biomass_liquidbelly"
 #define REAGENT_ID_CONCENTRATEDRADIUM_BELLY "cradium_liquidbelly"
 #define REAGENT_ID_TRICORDRAZINE_BELLY "tricordrazine_liquidbelly"
+
+// Outpost 21 edit begin - PPE affecting chems
+// into eyes
+#define REAGENT_PPE_GAS 		0x1
+#define REAGENT_PPE_DUST 		0x2
+#define REAGENT_PPE_SQUIRTS		0x4
+#define REAGENT_PPE_PHORONGAS	0x8
+// onto hands or suit
+#define REAGENT_PPE_SPLASH		0x10
+#define REAGENT_PPE_BUBBLES		0x20
+// burns hands
+#define REAGENT_PPE_BURNS		0x40
+#define REAGENT_PPE_FREEZES		0x80
+#define REAGENT_PPE_LAST		0x100
+// Outpost 21 edit end

--- a/code/modules/reagents/reagent_containers/_reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers/_reagent_containers.dm
@@ -64,6 +64,7 @@
 	var/trans = target.reagents.trans_to_obj(src, target:amount_per_transfer_from_this)
 	// to_chat(user, span_notice("You fill [src] with [trans] units of the contents of [target]."))
 	balloon_alert(user, "[trans] units transfered to \the [src]") // CHOMPEdit - Changed to balloon alert
+	target.reagents.ppe_affect(user) // Outpost 21 edit - Check PPE
 	return 1
 
 /obj/item/reagent_containers/proc/standard_splash_mob(var/mob/user, var/mob/target) // This goes into afterattack
@@ -164,6 +165,7 @@
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 	// to_chat(user, span_notice("You transfer [trans] units of the solution to [target]."))
 	balloon_alert(user, "transfered [trans] units to [target]") // CHOMPEdit - Balloon alerts! They're the future, I tell you.
+	target.reagents.ppe_affect(user) // Outpost 21 edit - Check PPE
 	return 1
 
 /obj/item/reagent_containers/proc/liquid_belly_check()

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -46,6 +46,7 @@
 
 	var/from_belly = FALSE
 	var/wiki_flag = 0 // Bitflags for secret/food/drink reagent sorting
+	var/ppe_flags = 0 // Outpost 21 edit - PPE affecting chems
 
 /datum/reagent/proc/remove_self(var/amount) // Shortcut
 	if(holder)

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -15,6 +15,8 @@
 	glass_name = "tomato juice"
 	glass_desc = "Are you sure this is tomato juice?"
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/blood/initialize_data(var/newdata)
 	..()
 	if(data && data["blood_colour"])
@@ -238,6 +240,8 @@
 	glass_name = REAGENT_ID_WATER
 	glass_desc = "The father of all refreshments."
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/water/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
@@ -334,6 +338,8 @@
 
 	glass_name = "welder fuel"
 	glass_desc = "Unless you are an industrial tool, this is probably not safe for consumption."
+
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_PHORONGAS // Outpost 21 edit - PPE reagents
 
 /datum/reagent/fuel/touch_turf(var/turf/T, var/amount)
 	..()

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -66,6 +66,8 @@
 	reagent_state = GAS
 	color = "#808080"
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH|REAGENT_PPE_BURNS // Outpost 21 edit - PPE reagents
+
 /datum/reagent/chlorine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.take_organ_damage(1*REM, 0)
 
@@ -222,6 +224,8 @@
 	reagent_state = GAS
 	color = "#808080"
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/fluorine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(removed)
 
@@ -235,6 +239,8 @@
 	taste_mult = 0 //no taste
 	reagent_state = GAS
 	color = "#808080"
+
+	ppe_flags = REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/iron
 	name = REAGENT_IRON
@@ -252,6 +258,8 @@
 	reagent_state = SOLID
 	color = "#808080"
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/lithium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		if(M.canmove && !M.restrained() && istype(M.loc, /turf/space) && !M.resting) // Outpost 21 edit - Resting stops drug movement
@@ -266,6 +274,8 @@
 	taste_mult = 0 //mercury apparently is tasteless. IDK
 	reagent_state = LIQUID
 	color = "#484848"
+
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/mercury/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -291,6 +301,8 @@
 	reagent_state = GAS
 	color = "#808080"
 
+	ppe_flags = REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/oxygen/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.species.poison_type == GAS_O2) // outpost 21 edit, changed from alien == IS_VOX to be consistant with poison oxygen behavior
 		M.adjustToxLoss(removed * 3)
@@ -302,6 +314,8 @@
 	taste_description = "vinegar"
 	reagent_state = SOLID
 	color = "#832828"
+
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/potassium
 	name = REAGENT_POTASSIUM
@@ -318,6 +332,8 @@
 	taste_mult = 0	//Apparently radium is tasteless
 	reagent_state = SOLID
 	color = "#C7C7C7"
+
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/radium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(issmall(M)) removed *= 2
@@ -340,6 +356,8 @@
 	reagent_state = SOLID
 	color = "#C7C7C7"
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/radium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(issmall(M)) removed *= 2
 	M.apply_effect(10 * removed, IRRADIATE, 0) // Radium may increase your chances to cure a disease
@@ -360,6 +378,8 @@
 	var/power = 5
 	var/meltdose = 10 // How much is needed to melt
 	affects_robots = TRUE //CHOMPedit, it's acid! Still eats metal!
+
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_GREY) //ywedit

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -23,6 +23,8 @@
 	mrate_static = TRUE
 	overdose = REAGENTS_OVERDOSE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/drugs/affect_blood(mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -11,6 +11,8 @@
 	metabolism = REM * 0.2
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/inaprovaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_STABLE, 15)
@@ -29,6 +31,8 @@
 	scannable = 1
 	touch_met = REM * 0.3
 	can_overdose_touch = TRUE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/inaprovaline/topical/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -51,6 +55,8 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_mod = 0.25
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
@@ -88,6 +94,8 @@
 	scannable = 1
 	touch_met = REM * 0.75
 	can_overdose_touch = TRUE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/bicaridine/topical/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
@@ -133,6 +141,8 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/kelotane/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -153,6 +163,8 @@
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/dermaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -172,6 +184,8 @@
 	scannable = 1
 	touch_met = REM * 0.75
 	can_overdose_touch = TRUE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/dermaline/topical/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
@@ -197,6 +211,8 @@
 	color = "#00A000"
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/dylovene/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -219,6 +235,8 @@
 	scannable = 1
 	overdose = REAGENTS_OVERDOSE * 0.5
 	overdose_mod = 0 // Not used, but it shouldn't deal toxin damage anyways. Carth heals toxins!
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
@@ -256,6 +274,8 @@
 	scannable = 1
 	metabolism = REM * 0.25
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 24)
@@ -281,6 +301,8 @@
 	overdose_mod = 1.25
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/dexalinp/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
 		M.adjustToxLoss(removed * 9)
@@ -305,6 +327,7 @@
 	scannable = 1
 	//YW ADDITIONS START
 	overdose = REAGENTS_OVERDOSE * 8 //240 overdose // Outpost 21 edit - raised overdose
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 /datum/reagent/tricordrazine/overdose(var/mob/living/carbon/M, var/alien)
 	..()
 	M.druggy = max(M.druggy, 5)
@@ -333,6 +356,8 @@
 	color = "#B060FF"
 	scannable = 1
 	can_overdose_touch = TRUE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/tricorlidaze/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
@@ -371,6 +396,8 @@
 	mrate_static = TRUE
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH|REAGENT_PPE_FREEZES // Outpost 21 edit - PPE reagents
+
 /datum/reagent/cryoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
 		var/chem_effective = 1 * M.species.chem_strength_heal
@@ -395,6 +422,8 @@
 	metabolism = REM * 0.5
 	mrate_static = TRUE
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH|REAGENT_PPE_FREEZES // Outpost 21 edit - PPE reagents
 
 /datum/reagent/clonexadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 170)
@@ -462,6 +491,8 @@
 	scannable = 1
 	affects_dead = TRUE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH|REAGENT_PPE_FREEZES // Outpost 21 edit - PPE reagents
+
 /datum/reagent/necroxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	if(M.bodytemperature < 170 || (M.stat == DEAD && M.has_modifier_of_type(/datum/modifier/bloodpump_corpse)))
@@ -498,6 +529,8 @@
 	metabolism = 0.02
 	mrate_static = TRUE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/paracetamol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_pain
 	if(alien == IS_SLIME)
@@ -523,6 +556,8 @@
 	metabolism = 0.02
 	mrate_static = TRUE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/tramadol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_pain
 	if(alien == IS_SLIME)
@@ -546,6 +581,8 @@
 	scannable = 1
 	metabolism = 0.02
 	mrate_static = TRUE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/oxycodone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_pain
@@ -573,6 +610,8 @@
 	metabolism = REM * 0.05
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/chem_effective = 1 * M.species.chem_strength_heal
@@ -602,6 +641,8 @@
 	color = "#FF3300"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	overdose_mod = 0.25
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_TAJARA)
@@ -634,6 +675,8 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
@@ -656,6 +699,8 @@
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/imidazoline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.eye_blurry = max(M.eye_blurry - 5, 0)
@@ -681,6 +726,8 @@
 	overdose = 10
 	overdose_mod = 1.5
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/peridaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
@@ -715,6 +762,8 @@
 	overdose_mod = 1.5
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/osteodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
@@ -747,6 +796,8 @@
 	overdose_mod = 1.5
 	scannable = 1
 	var/repair_strength = 6
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/myelamine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
@@ -795,6 +846,8 @@
 	overdose_mod = 1.75
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/respirodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/repair_strength = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -827,6 +880,8 @@
 	overdose_mod = 1.75
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/gastirodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/repair_strength = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -858,6 +913,8 @@
 	overdose = 10
 	overdose_mod = 1.75
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/hepanephrodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/repair_strength = 1 * M.species.chem_strength_heal
@@ -893,6 +950,8 @@
 	overdose_mod = 1.75
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/cordradaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/repair_strength = 1 * M.species.chem_strength_heal
 	if(alien == IS_SLIME)
@@ -921,6 +980,8 @@
 	overdose_mod = 1.5
 	scannable = 1
 	metabolism = REM * 0.06
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/immunosuprizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/strength_mod = 1 // * M.species.chem_strength_heal //Just removing the chem strength adjustment. It'd require division, which is best avoided.
@@ -1017,6 +1078,8 @@
 	color = "#004000"
 	overdose = REAGENTS_OVERDOSE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/ryetalyn/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	//Ryetalyn is for genetics damage curing not resetting mutations, breaks traitgenes
 	if(alien == IS_DIONA)
@@ -1049,6 +1112,8 @@
 	reagent_state = SOLID
 	color = "#605048"
 	overdose = REAGENTS_OVERDOSE
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/ethylredoxrazine/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
@@ -1085,6 +1150,8 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/hyronalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
@@ -1102,6 +1169,8 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_mod = 1.25
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/arithrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
@@ -1124,6 +1193,8 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
 	data = 0
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -1153,6 +1224,8 @@
 	overdose_mod = 1.5
 	scannable = 1
 	data = 0
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/corophizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -1223,6 +1296,8 @@
 	data = 0
 	can_overdose_touch = TRUE
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/spacomycaze/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, 10 * M.species.chem_strength_pain)
 	M.adjustToxLoss(3 * removed)
@@ -1266,6 +1341,8 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	touch_met = 5
+
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH|REAGENT_PPE_BURNS|REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS // Outpost 21 edit - PPE reagents
 
 /datum/reagent/sterilizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_SLIME)
@@ -1317,6 +1394,9 @@
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+
+	ppe_flags = REAGENT_PPE_BURNS|REAGENT_PPE_FREEZES // Outpost 21 edit - PPE reagents
+
 
 /datum/reagent/leporazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -13,6 +13,8 @@
 	var/strength = 4 // How much damage it deals per unit
 	var/skin_danger = 0.2 // The multiplier for how effective the toxin is when making skin contact.
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/poison_strength = strength * M.species.chem_strength_tox
 	if(strength && alien != IS_DIONA)
@@ -46,6 +48,8 @@
 	color = "#792300"
 	strength = 10
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/toxin/amatoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	// Trojan horse. Waits until most of the toxin has gone through the body before dealing the bulk of it in one big strike.
 	if(volume < max_dose * 0.2)
@@ -59,6 +63,8 @@
 	reagent_state = LIQUID
 	color = "#003333"
 	strength = 10
+
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/toxin/carpotoxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -95,6 +101,8 @@
 	description = "An exceptionally flammable molecule formed from deuterium synthesis."
 	strength = 80
 	var/fire_mult = 30
+
+	ppe_flags = REAGENT_PPE_PHORONGAS|REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/toxin/hydrophoron/touch_mob(var/mob/living/L, var/amount)
 	..()
@@ -139,6 +147,8 @@
 	color = "#2CE893"
 	strength = 5
 
+	ppe_flags = REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/toxin/phoron
 	name = REAGENT_PHORON
 	id = REAGENT_ID_PHORON
@@ -149,6 +159,8 @@
 	strength = 30
 	touch_met = 5
 	skin_danger = 1
+
+	ppe_flags = REAGENT_PPE_PHORONGAS|REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/toxin/phoron/touch_mob(var/mob/living/L, var/amount)
 	..()
@@ -189,6 +201,8 @@
 	color = "#CF3600"
 	strength = 15
 	metabolism = REM * 0.5
+
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/toxin/cyanide/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -319,6 +333,8 @@
 	strength = 3
 	mrate_static = TRUE
 
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/toxin/zombiepowder/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien == IS_DIONA)
@@ -344,6 +360,8 @@
 	metabolism = REM * 0.75
 	strength = 2
 	mrate_static = TRUE
+
+	ppe_flags = REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/toxin/lichpowder/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -412,6 +430,8 @@
 	color = "#49002E"
 	strength = 4
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/toxin/plantbgone/touch_turf(var/turf/T)
 	..()
 	if(istype(T, /turf/simulated/wall))
@@ -478,6 +498,8 @@
 	power = 10
 	meltdose = 4
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_BURNS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/acid/digestive
 	name = REAGENT_STOMACID
 	id = REAGENT_ID_STOMACID
@@ -489,6 +511,8 @@
 	meltdose = 30
 	wiki_flag = WIKI_SPOILER
 
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
+
 /datum/reagent/acid/diet_digestive
 	name = REAGENT_DIETSTOMACID
 	id = REAGENT_ID_DIETSTOMACID
@@ -499,6 +523,8 @@
 	power = 0.4
 	meltdose = 150
 	wiki_flag = WIKI_SPOILER
+
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_BUBBLES|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/thermite/venom
 	name = REAGENT_THERMITEV
@@ -531,6 +557,8 @@
 	color = "#B31008"
 	filtered_organs = list(O_SPLEEN)
 	wiki_flag = WIKI_SPOILER
+
+	ppe_flags = REAGENT_PPE_GAS|REAGENT_PPE_SQUIRTS|REAGENT_PPE_SPLASH // Outpost 21 edit - PPE reagents
 
 /datum/reagent/condensedcapsaicin/venom/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)

--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -12,6 +12,8 @@
 	metabolism = 0.01
 	mrate_static = TRUE
 
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
+
 /datum/reagent/macrocillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/new_size = clamp((M.size_multiplier + 0.01), RESIZE_MINIMUM_DORMS, RESIZE_MAXIMUM_DORMS)
 	M.resize(new_size, animate = FALSE, uncapped = M.has_large_resize_bounds()) //Incrrease 1% per tick. //CHOMP Edit: don't do fancy animates. Unnecessary on 1% changes. Laggy.
@@ -25,6 +27,8 @@
 	color = "#800080"
 	metabolism = 0.01
 	mrate_static = TRUE
+
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
 
 /datum/reagent/microcillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/new_size = clamp((M.size_multiplier - 0.01), RESIZE_MINIMUM_DORMS, RESIZE_MAXIMUM_DORMS)
@@ -40,6 +44,8 @@
 	color = "#00FFFF"
 	metabolism = 0.01 //One unit will be just enough to bring someone from 200% to 100%
 	mrate_static = TRUE
+
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
 
 /datum/reagent/normalcillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.size_multiplier > RESIZE_NORMAL)
@@ -57,6 +63,8 @@
 	color = "#1E90FF"
 	overdose = REAGENTS_OVERDOSE
 
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
+
 /datum/reagent/sizeoxadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.make_dizzy(1)
 	if(!M.confused) M.confused = 1
@@ -73,6 +81,8 @@
 	reagent_state = LIQUID
 	color = "#0E900E"
 	overdose = REAGENTS_OVERDOSE
+
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
 
 /datum/reagent/ickypak/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.make_dizzy(1)
@@ -95,6 +105,8 @@
 	reagent_state = LIQUID
 	color = "#EF77E5"
 	overdose = REAGENTS_OVERDOSE
+
+	ppe_flags = REAGENT_PPE_SPLASH|REAGENT_PPE_BUBBLES // Outpost 21 edit - PPE reagents
 
 /datum/reagent/unsorbitol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.make_dizzy(1)

--- a/modular_outpost/code/modules/reagents/reagents/reagent_ppe.dm
+++ b/modular_outpost/code/modules/reagents/reagents/reagent_ppe.dm
@@ -1,0 +1,105 @@
+/datum/reagents/proc/ppe_affect(var/mob/living/user)
+	if(!isliving(user))
+		return
+	if(!reagent_list.len)
+		return
+	if(prob(90))
+		return
+	var/datum/reagent/R = pick(reagent_list)
+	if(!R.ppe_flags)
+		return
+
+	// Is it in our hands?
+	var/affect_hand = 0
+	if(user.r_hand == my_atom)
+		affect_hand = 1
+	if(user.l_hand == my_atom)
+		affect_hand = 2
+
+	// Get our protections
+	var/has_gloves = FALSE
+	var/has_goggles = FALSE
+	var/has_suit = FALSE
+	var/phoron_immune = FALSE
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.gloves)
+			has_gloves = TRUE
+
+		if(H.glasses && (H.glasses.body_parts_covered & EYES))
+			has_goggles = TRUE
+		else if(H.head && (H.head.body_parts_covered & EYES))
+			has_goggles = TRUE
+
+		if(H.wear_suit)
+			has_suit = TRUE
+
+		if(H.species.name == SPECIES_VOX || H.species.phoron_contact_mod < 0.1)
+			phoron_immune = TRUE
+
+	// Check the PPE effects
+	var/list/ppe_check = list()
+	var/i = 1
+	while(i < REAGENT_PPE_LAST)
+		if(R.ppe_flags & i)
+			ppe_check.Add(i)
+		i*=2
+	var/flag_checking = pick(ppe_check)
+	var/actual_action = 0
+
+	// first do description of action
+	switch(flag_checking)
+		if(REAGENT_PPE_GAS)
+			if(!has_goggles)
+				to_chat(user,span_danger("The [my_atom]'s mist blows into your eyes!"))
+				actual_action = REAGENT_PPE_GAS
+		if(REAGENT_PPE_DUST)
+			if(!has_goggles)
+				to_chat(user,span_danger("The [my_atom]'s dust blows into your eyes!"))
+				actual_action = REAGENT_PPE_GAS
+		if(REAGENT_PPE_SQUIRTS)
+			if(!has_goggles)
+				to_chat(user,span_danger("The [my_atom] squirts into your eyes!"))
+				actual_action = REAGENT_PPE_GAS
+		if(REAGENT_PPE_PHORONGAS)
+			if(!has_goggles && !phoron_immune)
+				to_chat(user,span_danger("The [my_atom]'s mist blows into your eyes!"))
+				actual_action = REAGENT_PPE_GAS
+
+		if(REAGENT_PPE_SPLASH)
+			if((!has_suit || !has_gloves) && affect_hand)
+				to_chat(user,span_danger("The [my_atom] splashes onto you!"))
+				actual_action = REAGENT_PPE_SPLASH
+		if(REAGENT_PPE_BUBBLES)
+			if((!has_suit || !has_gloves) && affect_hand)
+				to_chat(user,span_danger("The [my_atom] overflows with foam onto you!"))
+				actual_action = REAGENT_PPE_SPLASH
+
+		if(REAGENT_PPE_BURNS)
+			if(!has_gloves && affect_hand)
+				to_chat(user,span_danger("The [my_atom] becomes painfully hot in your hand!"))
+				actual_action = REAGENT_PPE_BURNS
+		if(REAGENT_PPE_FREEZES)
+			if(!has_gloves && affect_hand)
+				to_chat(user,span_danger("The [my_atom] becomes painfully cold in your hand!"))
+				actual_action = REAGENT_PPE_BURNS
+
+	// Now do the actual effect... much more simple
+	if(!actual_action)
+		return
+	switch(actual_action)
+		if(REAGENT_PPE_GAS)
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				var/obj/item/organ/internal/eyes/O = H.internal_organs_by_name[O_EYES]
+				if(O && O.robotic <= ORGAN_ASSISTED)
+					O.damage += rand(2,5)
+
+		if(REAGENT_PPE_SPLASH)
+			R.touch_mob(user,rand(1,3))
+
+		if(REAGENT_PPE_BURNS)
+			if(affect_hand == 1)
+				user.apply_damage(rand(2,5),SEARING,BP_R_HAND)
+			if(affect_hand == 2)
+				user.apply_damage(rand(2,5),SEARING,BP_L_HAND)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5400,6 +5400,7 @@
 #include "modular_outpost\code\modules\reagents\reagents\dispenser.dm"
 #include "modular_outpost\code\modules\reagents\reagents\food_drinks.dm"
 #include "modular_outpost\code\modules\reagents\reagents\medicine.dm"
+#include "modular_outpost\code\modules\reagents\reagents\reagent_ppe.dm"
 #include "modular_outpost\code\modules\recycling\disposal.dm"
 #include "modular_outpost\code\modules\research\origin_tech_overrides.dm"
 #include "modular_outpost\code\modules\research\designs\misc.dm"


### PR DESCRIPTION
Chemicals cause various effects from being carelessly handled, such as splashing, gassing, dusting, or otherwise causing minor injuries if you do not wear any ppe.