### PR TITLE
Main Tesla engine rework, PTL

### DIFF
--- a/modular_outpost/maps/outpost_21/outpost-06-confinementbeam.dmm
+++ b/modular_outpost/maps/outpost_21/outpost-06-confinementbeam.dmm
@@ -1306,14 +1306,60 @@
 	},
 /turf/simulated/floor/airless,
 /area/ai_sat/power_control)
+"cL" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/vending/coffee{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/offworld/confinementbeam/station/hallway_alt)
 "cM" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/old_tile/white,
 /area/offworld/confinementbeam/station/medical_treatment)
+"cN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/tesla_coil/collector,
+/turf/simulated/floor/airless,
+/area/offworld/confinementbeam/exterior)
+"cO" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/tesla_coil/collector,
+/turf/simulated/floor/airless,
+/area/offworld/confinementbeam/exterior)
 "cP" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 1
 	},
+/turf/simulated/floor/airless,
+/area/offworld/confinementbeam/exterior)
+"cQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/tesla_coil/collector,
 /turf/simulated/floor/airless,
 /area/offworld/confinementbeam/exterior)
 "cR" = (
@@ -1321,6 +1367,13 @@
 /obj/machinery/camera/network/engineering_outpost{
 	c_tag = "PTL - Solar Exterior"
 	},
+/turf/simulated/floor/airless,
+/area/offworld/confinementbeam/exterior)
+"cS" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tesla_coil/collector,
 /turf/simulated/floor/airless,
 /area/offworld/confinementbeam/exterior)
 "cU" = (
@@ -2177,13 +2230,6 @@
 /obj/structure/confinement_beam_generator/lens/outer_lens,
 /turf/simulated/floor/plating,
 /area/offworld/confinementbeam/station/beam_emitter)
-"fx" = (
-/obj/machinery/power/tesla_coil/collector,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/airless,
-/area/offworld/confinementbeam/exterior)
 "fA" = (
 /obj/machinery/camera/network/substations{
 	c_tag = "AI - South turret"
@@ -3056,6 +3102,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/vending/foodmeat{
+	dir = 4;
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/offworld/confinementbeam/station/hallway_alt)
 "in" = (
@@ -3444,6 +3494,10 @@
 /obj/effect/floor_decal/corner/orange/full{
 	dir = 1
 	},
+/obj/machinery/vending/cigarette{
+	dir = 8;
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/offworld/confinementbeam/station/starboard_observation)
 "jA" = (
@@ -3646,16 +3700,6 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/offworld/confinementbeam/station/starboard_equipment)
-"kq" = (
-/obj/machinery/power/tesla_coil/collector,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless,
-/area/offworld/confinementbeam/exterior)
 "ks" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -9905,16 +9949,6 @@
 "DK" = (
 /turf/simulated/floor/airless,
 /area/ai_sat/core_external)
-"DM" = (
-/obj/machinery/power/tesla_coil/collector,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless,
-/area/offworld/confinementbeam/exterior)
 "DN" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/milspec,
@@ -12793,6 +12827,10 @@
 "My" = (
 /obj/effect/floor_decal/corner/orange/full{
 	dir = 4
+	},
+/obj/machinery/vending/cola{
+	dir = 8;
+	pixel_x = 8
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/offworld/confinementbeam/station/port_observation)
@@ -16581,16 +16619,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/rad_floor/yellow,
-/turf/simulated/floor/airless,
-/area/offworld/confinementbeam/exterior)
-"YA" = (
-/obj/machinery/power/tesla_coil/collector,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/airless,
 /area/offworld/confinementbeam/exterior)
 "YB" = (
@@ -47215,7 +47243,7 @@ Po
 Po
 yl
 Po
-Po
+yl
 Po
 rc
 Po
@@ -47371,25 +47399,25 @@ Po
 Po
 Po
 Po
-Po
+yl
 Po
 Po
 Po
 yl
 Po
-Po
-Po
+yl
+yl
 rc
-Po
-Po
-Po
-Po
-Po
-Po
+yl
+yl
+yl
+yl
+yl
+yl
 rc
-Po
-Po
-Po
+yl
+yl
+yl
 Po
 Po
 Po
@@ -47533,29 +47561,29 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-yl
-Po
-Po
-Po
-rc
-Po
-Po
-Po
-yl
-yl
 yl
 rc
-Po
-Po
+rc
+rc
+rc
+rc
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
 yl
 yl
 yl
-Po
-Po
+yl
+yl
 Po
 Po
 rc
@@ -47695,25 +47723,25 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
 Po
-rc
 Po
-yl
-yl
-yl
-Po
-Po
-rc
-yl
-yl
-yl
+rW
+rW
+Qe
+pl
+pl
+pl
+pl
+pl
+aP
+pl
+pl
+pl
+pl
+pR
 Po
 Po
 Po
@@ -47857,11 +47885,10 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+rc
+Po
+Po
 Po
 Po
 Po
@@ -47871,12 +47898,13 @@ Po
 Po
 Po
 Po
-Po
 rc
 Po
 Po
 Po
 Po
+rW
+SN
 Po
 Po
 Po
@@ -48019,27 +48047,27 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+rc
+rc
+Po
 Po
 Po
 Po
 rc
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
 Po
+Po
+Po
+Po
+Po
+rc
+Po
+Po
+Po
+Po
+Po
+rW
+SN
 Po
 Po
 Po
@@ -48181,28 +48209,28 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 rc
 rc
+Po
+Po
+Po
+rc
+Po
+Po
+Po
+Po
+Po
+rc
+Po
+Po
+Po
+Po
+Po
 rc
 rW
-rW
-Qe
-pl
-pl
-pl
-pl
-pl
-aP
-pl
-pl
-pl
-pl
-pl
+BL
 pl
 pR
 rW
@@ -48343,14 +48371,11 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
-Po
+rc
+rc
 Po
 Po
 rc
@@ -48363,6 +48388,9 @@ rc
 Po
 Po
 Po
+Po
+rc
+rc
 Po
 Po
 Po
@@ -48505,15 +48533,12 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
 Po
-Po
+rc
+rc
 Po
 rc
 Po
@@ -48524,6 +48549,9 @@ Po
 rc
 Po
 Po
+Po
+rc
+rc
 Po
 Po
 Po
@@ -48667,16 +48695,13 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
 Po
 Po
-Po
+rc
+rc
 rc
 Po
 Po
@@ -48686,6 +48711,9 @@ Po
 rc
 rc
 qL
+rc
+rc
+Po
 Po
 Po
 Po
@@ -48829,25 +48857,25 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 Po
 Po
 Po
 Po
 du
 rW
-fx
+cS
 ud
 ud
 ud
-DM
+cQ
 ud
 wM
 rc
+rc
+Po
+Po
 Po
 Po
 Kv
@@ -48991,12 +49019,9 @@ Po
 Po
 Po
 Po
-Po
-yl
-Po
-Po
 yl
 eG
+Po
 Po
 Po
 Po
@@ -49010,6 +49035,9 @@ Po
 Hq
 qu
 kg
+Po
+Po
+Po
 Po
 Po
 qC
@@ -49154,9 +49182,6 @@ Po
 Po
 Po
 Po
-yl
-Po
-Po
 Po
 Po
 Po
@@ -49170,8 +49195,11 @@ Po
 rc
 Po
 Po
-YA
+cN
 rc
+Po
+Po
+Po
 Po
 Po
 Kv
@@ -49312,11 +49340,8 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 Po
 Po
 Po
@@ -49333,6 +49358,9 @@ rW
 rc
 rc
 RV
+ud
+ud
+ud
 ud
 ud
 ud
@@ -49474,11 +49502,8 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+rc
 rc
 rc
 rc
@@ -49496,6 +49521,9 @@ Po
 Po
 qu
 rc
+Po
+Po
+Po
 Po
 Po
 qu
@@ -49636,11 +49664,8 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 Po
 Po
 Po
@@ -49657,6 +49682,9 @@ rW
 rc
 rc
 Ew
+ud
+ud
+ud
 ud
 ud
 ud
@@ -49798,11 +49826,8 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 Po
 Po
 Po
@@ -49818,8 +49843,11 @@ Po
 rc
 Po
 Po
-kq
+cO
 rc
+Po
+Po
+Po
 Po
 kk
 Kv
@@ -49960,11 +49988,8 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
 Po
 Po
 Po
@@ -49982,6 +50007,9 @@ Po
 Hq
 qu
 rc
+Po
+Po
+Po
 Po
 Po
 Kv
@@ -50122,10 +50150,7 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
+yl
 Po
 Po
 Po
@@ -50136,14 +50161,17 @@ Po
 Po
 du
 rW
-fx
+cS
 ud
 ud
 ud
-DM
+cQ
 ud
 Ib
 rc
+rc
+Po
+Po
 Po
 Po
 Sy
@@ -50284,12 +50312,6 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
@@ -50297,6 +50319,9 @@ Po
 Po
 Po
 Po
+Po
+rc
+rc
 rc
 Po
 Po
@@ -50306,6 +50331,9 @@ Po
 rc
 rc
 qL
+rc
+rc
+Po
 Po
 Po
 Po
@@ -50446,12 +50474,6 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
-Po
 yl
 Po
 Po
@@ -50460,6 +50482,9 @@ Po
 Po
 Po
 rc
+rc
+Po
+rc
 Po
 Po
 Po
@@ -50468,6 +50493,9 @@ Po
 rc
 Po
 Po
+Po
+rc
+rc
 Po
 Po
 Po
@@ -50614,11 +50642,8 @@ Po
 Po
 Po
 Po
-yl
-Po
-Po
-Po
-Po
+rc
+rc
 Po
 Po
 rc
@@ -50631,6 +50656,9 @@ rc
 Po
 Po
 Po
+Po
+rc
+rc
 Po
 Po
 Po
@@ -50772,29 +50800,29 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
+Po
+Po
 rc
 rc
+Po
+Po
+Po
 rc
+Po
+Po
+Po
+Po
+Po
+rc
+Po
+Po
+Po
+Po
+Po
 rc
 rW
-rW
-Ai
-pl
-pl
-aW
-pl
-pl
-Fn
-pl
-pl
-pl
-pl
-pl
+OW
 pl
 Oe
 rW
@@ -50934,28 +50962,28 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
+rc
+rc
 Po
 Po
 Po
 Po
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
-rW
+rc
 Po
+Po
+Po
+Po
+Po
+rc
+Po
+Po
+Po
+Po
+Po
+rW
+mv
 Po
 Po
 Po
@@ -51096,12 +51124,10 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
 Po
+rc
+Po
 Po
 Po
 Po
@@ -51112,11 +51138,13 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 rc
+Po
+Po
+Po
+Po
+rW
+mv
 Po
 Po
 Po
@@ -51258,26 +51286,26 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
 yl
-yl
-Po
-Po
-Po
-Po
 rc
-Po
-Po
-Po
-Po
-Po
-Po
-Po
-Po
-Po
+rc
+rc
+rc
+rc
+rW
+rW
+Ai
+pl
+pl
+aW
+pl
+pl
+Fn
+pl
+pl
+pl
+pl
+Oe
 rc
 Po
 Po
@@ -51420,25 +51448,25 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
-yl
 yl
 Po
 Po
 Po
-rc
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
+rW
 Po
 rc
 Po
@@ -51582,17 +51610,17 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
+yl
 Po
 Po
 Po
 yl
-yl
+Po
+Po
 Po
 Po
 rc
+Po
 Po
 Po
 Po
@@ -51744,17 +51772,17 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
+yl
+yl
 Po
 Po
 yl
 yl
+yl
+Po
 Po
 rc
+Po
 Po
 Po
 Po
@@ -51912,15 +51940,15 @@ Po
 Po
 Po
 Po
+yl
+yl
+Po
+rc
 Po
 Po
-yl
-yl
-yl
-yl
-yl
-yl
-yl
+Po
+Po
+Po
 Po
 yl
 yl
@@ -52075,13 +52103,13 @@ Po
 Po
 Po
 Po
-Po
-Po
-Po
-Po
-Po
-Po
-Po
+yl
+yl
+yl
+yl
+yl
+yl
+yl
 Po
 Po
 Po
@@ -52434,7 +52462,7 @@ mG
 cb
 yD
 kz
-Aj
+cL
 Sh
 kv
 bz


### PR DESCRIPTION
Increased the size of the main Tesla building area on the PTL to entice players to build more complex Tesla engines and promote experimenting with the engine.

Also added four new vending machines to the PTL to add variety and increase the total from 2 to 6 machines.

