### PR TITLE
Cargo Borg Gameplay

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -664,6 +664,8 @@
 	src.modules += new /obj/item/card/id/cargo/miner/borg(src)
 	src.modules += new /obj/item/gun/energy/robotic/phasegun(src) //CHOMPedit: Phasegun for regular mining cyborg.
 	src.modules += new /obj/item/vac_attachment(src) //CHOMPAdd
+	src.modules += new /obj/item/destTagger(src) // Outpost 21 edit(port) - Makes cargo borg possible
+	src.modules += new /obj/item/packageWrap/borg(src) // Outpost 21 edit(port) - Makes cargo borg possible
 	src.emag += new /obj/item/kinetic_crusher/machete/dagger(src)
 
 	var/datum/matter_synth/beacon = new /datum/matter_synth/beacon(10000)

--- a/code/modules/recycling/packagewrap.dm
+++ b/code/modules/recycling/packagewrap.dm
@@ -50,10 +50,15 @@
 			P.add_fingerprint(user)
 			O.add_fingerprint(user)
 			src.add_fingerprint(user)
-			src.amount -= 1
-			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
-			"You hear someone taping paper around a small object.")
+			if(is_robot_module(loc)) // Outpost 21 edit(port) - Makes cargo borg possible
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target]."),\
+				"You hear someone taping paper around a small object.")
+			else
+				src.amount -= 1
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+				"You hear someone taping paper around a small object.")
 			playsound(src, 'sound/items/package_wrap.ogg', 50, 1)
 	else if (istype(target, /obj/structure/closet/crate))
 		var/obj/structure/closet/crate/O = target
@@ -62,10 +67,15 @@
 			P.icon_state = "deliverycrate"
 			P.wrapped = O
 			O.loc = P
-			src.amount -= 3
-			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
-			"You hear someone taping paper around a large object.")
+			if(is_robot_module(loc)) // Outpost 21 edit(port) - Makes cargo borg possible
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target]."),\
+				"You hear someone taping paper around a large object.")
+			else
+				src.amount -= 3
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+				"You hear someone taping paper around a large object.")
 			playsound(src, 'sound/items/package_wrap.ogg', 50, 1)
 		else if(src.amount < 3)
 			to_chat(user, span_warning("You need more paper."))
@@ -76,10 +86,15 @@
 			P.wrapped = O
 			O.sealed = 1
 			O.loc = P
-			src.amount -= 3
-			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
-			"You hear someone taping paper around a large object.")
+			if(is_robot_module(loc)) // Outpost 21 edit(port) - Makes cargo borg possible
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target]."),\
+				"You hear someone taping paper around a large object.")
+			else
+				src.amount -= 3
+				user.visible_message("\The [user] wraps \a [target] with \a [src].",\
+				span_notice("You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
+				"You hear someone taping paper around a large object.")
 			playsound(src, 'sound/items/package_wrap.ogg', 50, 1)
 		else if(src.amount < 3)
 			to_chat(user, span_warning("You need more paper."))
@@ -93,5 +108,5 @@
 
 /obj/item/packageWrap/examine(mob/user)
 	. = ..()
-	if(get_dist(user, src) <= 0)
+	if(get_dist(user, src) <= 0 && !is_robot_module(loc)) // Outpost 21 edit(port) - Makes cargo borg possible
 		. += span_blue("There are [amount] units of package wrap left!")

--- a/modular_outpost/code/modules/recycling/packagewrap.dm
+++ b/modular_outpost/code/modules/recycling/packagewrap.dm
@@ -1,0 +1,16 @@
+/obj/item/packageWrap/borg
+	name = "packaging dispenser"
+	desc = "Wraps various items so they can be tagged and shipped through disposals."
+	amount = 999
+
+// Unwrapping
+/obj/item/smallDelivery/attack_robot(mob/living/user)
+	to_chat(world,"WAT 1")
+	if(user.stat || !Adjacent(user))
+		return
+	attack_self(user)
+
+/obj/structure/bigDelivery/attack_robot(mob/living/user)
+	if(user.stat || !Adjacent(user))
+		return
+	unwrap()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5896,6 +5896,7 @@
 #include "modular_outpost\code\modules\reagents\reagents\other.dm"
 #include "modular_outpost\code\modules\reagents\reagents\reagent_ppe.dm"
 #include "modular_outpost\code\modules\recycling\disposal.dm"
+#include "modular_outpost\code\modules\recycling\packagewrap.dm"
 #include "modular_outpost\code\modules\research\designs\ai_designs.dm"
 #include "modular_outpost\code\modules\research\designs\chomp_designs.dm"
 #include "modular_outpost\code\modules\research\designs\circuitry_designs.dm"


### PR DESCRIPTION
Adds a packing wrapper and destination tagger to mining borgs. Mostly because outpost mining borgs are a bit useless without a jetpack. So being stuck on cargoduty is a lot more common here. Makes it possible to engage with the mailing system at all as a borg. Also allows borgs to open packages.