### PR TITLE
Natural tunneler trait

### DIFF
--- a/code/__defines/traits/declarations_op.dm
+++ b/code/__defines/traits/declarations_op.dm
@@ -4,3 +4,4 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 #define TRAIT_GOLDDIGGER "trait_golddigger"
 #define TRAIT_MUTATIONCASCADE "trait_mutationcascade"
+#define TRAIT_NATURALTUNNELER "trait_naturaldtunneler"

--- a/code/_global_vars/traits.dm
+++ b/code/_global_vars/traits.dm
@@ -99,6 +99,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		// Outpost 21 edit begin - Custom traits
 		"TRAIT_GOLDDIGGER" = TRAIT_GOLDDIGGER,
 		"TRAIT_MUTATIONCASCADE" = TRAIT_MUTATIONCASCADE,
+		"TRAIT_NATURALTUNNELER" = TRAIT_NATURALTUNNELER,
 		// Outpost 21 edit end
 	),
 	/*

--- a/modular_outpost/code/modules/mining/mine_turfs.dm
+++ b/modular_outpost/code/modules/mining/mine_turfs.dm
@@ -15,3 +15,44 @@
 
 /turf/simulated/mineral/crystal_shiny/ignore_mapgen
 	ignore_cavegen = TRUE
+
+
+// Natural tunneler trait
+/turf/simulated/mineral/attack_hand(mob/user)
+	if(HAS_TRAIT(user, TRAIT_NATURALTUNNELER) && density)
+		if(!istype(user.loc, /turf))
+			return
+
+		//prevents message spam
+		if(last_act + /obj/item/pickaxe::digspeed > world.time)
+			return
+		last_act = world.time
+
+		// Our claws are pretty gentle compared to a pick or drill
+		playsound(user, "pickaxe", 15, 1)
+		if(LAZYLEN(finds))
+			wreckfinds(FALSE)
+		user.balloon_alert(user, "you start digging.")
+
+		// Mine or release artifacts in rubble
+		if(do_after(user, 20 SECONDS, target = src))
+			if(LAZYLEN(finds))
+				var/datum/find/F = finds[1]
+				excavate_find(prob(70), F)
+			user.balloon_alert(user, "you finish digging \the [src].")
+			excavate_turf()
+		return
+	. = ..()
+
+/obj/item/strangerock/attack_hand(mob/living/user)
+	if(HAS_TRAIT(user, TRAIT_NATURALTUNNELER))
+		if(do_after(user, 2 SECONDS, target = src))
+			var/obj/item/inside = locate() in src
+			if(inside)
+				inside.loc = get_turf(src)
+				visible_message(span_info("\The [src] is dug away, revealing \the [inside]."))
+			else
+				visible_message(span_info("\The [src] is dug away into nothing."))
+			qdel(src)
+		return
+	. = ..()

--- a/modular_outpost/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/modular_outpost/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -58,3 +58,12 @@
 	name = "Disposable Body"
 	desc = "Autosleever respawn time reduced to 5 minutes regardless of what caused death."
 	cost = 12 // You really should know what this means by now
+
+/datum/trait/positive/naturaltunneler
+	name = "Natural Tunneller"
+	desc = "Using strong claws or inhuman strength you have the ability to carve your way through rough stone walls."
+	cost = 7
+
+/datum/trait/positive/naturaltunneler/apply(datum/species/S, mob/living/carbon/human/H, trait_prefs)
+	. = ..()
+	ADD_TRAIT(H, TRAIT_NATURALTUNNELER, ROUNDSTART_TRAIT)

--- a/modular_outpost/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/modular_outpost/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -60,7 +60,7 @@
 	cost = 12 // You really should know what this means by now
 
 /datum/trait/positive/naturaltunneler
-	name = "Natural Tunneller"
+	name = "Natural Tunneler"
 	desc = "Using strong claws or inhuman strength you have the ability to carve your way through rough stone walls."
 	cost = 7
 


### PR DESCRIPTION
Adds a trait that allows digging through stonewalls (and only stone walls/debris), at an extremely slow rate. Uncovers artifacts harmlessly, but using this for mining would be agonizing. Exists for gimmick custom species that can naturally burrow.

