### PR TITLE
Adds rank icon to examine text

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -135,7 +135,7 @@
 	// Outpost 21 edit begin - Eshui ranks
 	if(LAZYLEN(ranks_items))
 		for(var/obj/item/clothing/accessory/rank_eshui/pin in ranks_items)
-			msg += "[p_They()] [p_have()] the rank of [span_underline(span_bold(pin.rank))]."
+			msg += "[p_They()] [p_have()] the rank of [icon2html(pin,user.client)] [span_underline(span_bold(pin.rank))]."
 	// Outpost 21 edit end
 
 	//suit/armour


### PR DESCRIPTION

## About The Pull Request

This PR adds the icon for the corresponding rank to the examine text of the rank.

Example for the rank of E-1 (Recruit):
<img width="257" height="19" alt="image" src="https://github.com/user-attachments/assets/df0fdad4-ef30-438e-a070-17de2925345c" />

## Changelog
:cl:
add: Added icon of the rank to the examine text of the rank
/:cl:
