### PR TITLE
fluff ckey fix

### DIFF
--- a/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
+++ b/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
@@ -65,7 +65,7 @@
 	icon_x = 64
 	icon_y = 32
 
-	whitelist_ckey = "jademanique"
+	whitelist_ckey = "natesaruli"
 	whitelist_charname = "B.A.U-Kingside"
 
 // L


### PR DESCRIPTION

changes the Outpost Override fluff.dm to mirror correct ckey as base file fluff.dm does
