### PR TITLE
CommanDerg WL + Kingside sprite flag fix

### DIFF
--- a/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
+++ b/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
@@ -61,6 +61,7 @@
 	rest_sprite_options = list("Default", "Sit", "Bellyup")
 	has_dead_sprite = TRUE
 	has_dead_sprite_overlay = TRUE
+	sprite_flags = ROBOT_HAS_TASER_SPRITE | ROBOT_HAS_LASER_SPRITE
 	pixel_x = -16
 	icon_x = 64
 	icon_y = 32

--- a/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
+++ b/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
@@ -81,7 +81,7 @@
 	sprite_icon_state = "derg"
 	sprite_hud_icon_state = "k9"
 
-	has_eye_light_sprites = TRUE
+	has_eye_light_sprites = FALSE
 	has_vore_belly_sprites = TRUE
 	has_rest_sprites = TRUE
 	rest_sprite_options = list("Default", "Sit")
@@ -91,6 +91,7 @@
 	pixel_x = -16
 	icon_x = 64
 	icon_y = 64
+	vis_height = 64
 
 	whitelist_ckey = "natesaruli"
 	whitelist_charname = "SP-A.T"

--- a/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
+++ b/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
@@ -61,7 +61,6 @@
 	rest_sprite_options = list("Default", "Sit", "Bellyup")
 	has_dead_sprite = TRUE
 	has_dead_sprite_overlay = TRUE
-	sprite_flags = ROBOT_HAS_TASER_SPRITE | ROBOT_HAS_LASER_SPRITE
 	pixel_x = -16
 	icon_x = 64
 	icon_y = 32

--- a/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
+++ b/modular_outpost/code/modules/mob/living/silicon/robot/sprites/fluff.dm
@@ -61,6 +61,7 @@
 	rest_sprite_options = list("Default", "Sit", "Bellyup")
 	has_dead_sprite = TRUE
 	has_dead_sprite_overlay = TRUE
+	sprite_flags = ROBOT_HAS_TASER_SPRITE | ROBOT_HAS_LASER_SPRITE
 	pixel_x = -16
 	icon_x = 64
 	icon_y = 32
@@ -70,7 +71,29 @@
 
 // L
 
-/// S
+// N
+
+/datum/robot_sprite/fluff/natesaruli
+	name = CUSTOM_BORGSPRITE("CommanDerg")
+	module_type = "Command"
+
+	sprite_icon = 'icons/mob/robot/combat_large.dmi'
+	sprite_icon_state = "derg"
+	sprite_hud_icon_state = "k9"
+
+	has_eye_light_sprites = TRUE
+	has_vore_belly_sprites = TRUE
+	has_rest_sprites = TRUE
+	rest_sprite_options = list("Default", "Sit")
+	has_dead_sprite = TRUE
+	has_dead_sprite_overlay = FALSE
+	sprite_flags = 	ROBOT_HAS_SHIELD_SPRITE | ROBOT_HAS_GUN_SPRITE
+	pixel_x = -16
+	icon_x = 64
+	icon_y = 64
+
+	whitelist_ckey = "natesaruli"
+	whitelist_charname = "SP-A.T"
 
 /// T
 


### PR DESCRIPTION

Adds a borg whitelist entry for me to use Przyjaciel's derg borg sprite for SP-A.T as a Command cyborg, with permission from Przyjaciel and Ignus. Also adds missing flags to Kingside's whitelist entry for taser and gun sprites.
