### PR TITLE
Fixed attachment of new dogtags to clothing

### DIFF
--- a/modular_outpost/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/modular_outpost/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -17,12 +17,12 @@
 
 /datum/gear/accessory/dog_tag
 	display_name = "Dogtag selection"
-	path = /obj/item/accessory/dtag
+	path = /obj/item/clothing/accessory/dtag
 	cost = 0
 
 /datum/gear/accessory/dog_tag/New()
 	..()
 	var/list/tags = list()
-	for(var/obj/item/accessory/dtag/tag_type as anything in typesof(/obj/item/accessory/dtag))
+	for(var/obj/item/clothing/accessory/dtag/tag_type as anything in typesof(/obj/item/clothing/accessory/dtag))
 		tags[initial(tag_type.name)] = tag_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(tags))

--- a/modular_outpost/code/modules/clothing/accessories/fluff_awards.dm
+++ b/modular_outpost/code/modules/clothing/accessories/fluff_awards.dm
@@ -154,18 +154,18 @@ Internal confinement medals
 /*****
 Dogtags
 *****/
-/obj/item/accessory/dtag
+/obj/item/clothing/accessory/dtag
 	name = "Identification Tag"
 	desc = "A small medal ID plate with important information regarding the owner. Often called 'dogtags', despite allegations of specism from the vulpkanin."
 	icon = 'modular_outpost/icons/inventory/accessory/item.dmi'
 	icon_state = "dtags"
 
-/obj/item/accessory/dtag/medical
+/obj/item/clothing/accessory/dtag/medical
 	name = "Medical Information Tag"
 	desc = "A small metal ID plate colored blue to identify patient worries. Containing blood type, and any DNR information."
 	icon_state = "dtags_med"
 
-/obj/item/accessory/dtag/allergy
+/obj/item/clothing/accessory/dtag/allergy
 	name = "Allergy Information Tag"
 	desc = "A small metal ID plate colored bright red to warn medical staff of a potentially hazardous allergy in the patient."
 	icon_state = "dtags_aller"


### PR DESCRIPTION

## About The Pull Request

It was not possible to attach the new dog tags to clothing. After changing the path to /obj/item/clothing/accessory it is now attachable.

## Changelog
:cl:
fix: makes the new dog tags attachable to clothing
/:cl:
